### PR TITLE
Fixing Logger import for linux

### DIFF
--- a/src/Libs/getMetadata.js
+++ b/src/Libs/getMetadata.js
@@ -1,7 +1,7 @@
 import got from "got";
 import HttpsProxyAgent from "https-proxy-agent";
 import { constants, general } from "../Config";
-import logger from "./logger";
+import logger from "./Logger";
 
 async function getAppVersion(proxy) {
 	const params = constants.app.params(general.country, general.language);

--- a/src/Libs/index.js
+++ b/src/Libs/index.js
@@ -3,6 +3,6 @@ import {
 	getBuildVersion,
 	getAssetsVersion
 } from "./getMetadata";
-import logger from "./logger";
+import logger from "./Logger";
 
 export { logger, getAppVersion, getBuildVersion, getAssetsVersion };


### PR DESCRIPTION
Importing Logger seemed to work when not capitalized on Windows, but it's not the case on Linux. This fix solves the problem. 